### PR TITLE
Ignore CRC on bro input

### DIFF
--- a/scripts/bro-forensic.sh
+++ b/scripts/bro-forensic.sh
@@ -14,4 +14,4 @@ sed -i "s/DOCKERHOST/${DOCKERHOST}/g" /usr/local/bro/share/bro/bro-extra/conn_pc
 # set file permissions for apache
 chown www-data:www-data ${PCAPFILE}
 #cmd
-bro -r - -w ${PCAPFILE}
+bro -C -r - -w ${PCAPFILE}


### PR DESCRIPTION
I am reading network dumps with 

> docker exec  othercontainer  tcpdump -i eth0 -s -w - | nc localhost 1969 

However, the tcpdumps from containers lack correct CRC sums. I had to add `-C` to bro commandline to get these ethernet traces accepted by bro. 
